### PR TITLE
Completed

### DIFF
--- a/commons-security/src/main/java/com/fincity/saas/commons/security/feign/IFeignSecurityService.java
+++ b/commons-security/src/main/java/com/fincity/saas/commons/security/feign/IFeignSecurityService.java
@@ -36,6 +36,9 @@ public interface IFeignSecurityService {
 	@GetMapping("${security.feign.hasWriteAccess:/api/security/applications/internal/hasWriteAccess}")
 	public Mono<Boolean> hasWriteAccess(@RequestParam String appCode, @RequestParam String clientCode);
 
+    @GetMapping("${security.feign.validClientCode:/api/security/clients/internal/validateClientCode}")
+    public Mono<Boolean> validClientCode(@RequestParam String clientCode);
+
 	@GetMapping("${security.feign.hasWriteAccess:/api/security/applications/internal/appInheritance}")
 	public Mono<List<String>> appInheritance(@RequestParam String appCode, @RequestParam String urlClientCode,
 			@RequestParam String clientCode);

--- a/commons-security/src/main/java/com/fincity/saas/commons/security/service/FeignAuthenticationService.java
+++ b/commons-security/src/main/java/com/fincity/saas/commons/security/service/FeignAuthenticationService.java
@@ -125,4 +125,9 @@ public class FeignAuthenticationService implements IAuthenticationService {
 		return cacheService.cacheValueOrGet(CACHE_NAME_APP_WRITE_ACCESS,
 		        () -> this.feignAuthService.hasWriteAccess(appCode, clientCode), appCode, ":", clientCode);
 	}
+	
+    public Mono<Boolean> isValidClientCode(String clientCode) {
+
+        return this.feignAuthService.validClientCode(clientCode);
+    }
 }

--- a/files/src/main/java/com/fincity/saas/files/controller/AbstractResourceFileController.java
+++ b/files/src/main/java/com/fincity/saas/files/controller/AbstractResourceFileController.java
@@ -40,10 +40,12 @@ public abstract class AbstractResourceFileController<T extends AbstractFilesReso
 
 				SecurityContextUtil::getUsersContextAuthentication,
 
-				ca -> this.service.list(CommonsUtil.nonNullValue(clientCode, ca.getClientCode(), ca.getLoggedInFromClientCode()),
-						request.getURI()
-								.toString(),
-						fileType, filter, page),
+		        ca -> this.service.list(
+		                CommonsUtil.nonNullValue(clientCode, ca.getClientCode(), ca.getLoggedInFromClientCode()),
+		                request.getPath()
+		                        .toString(),
+		                fileType, filter,
+		                page),
 
 				(ca, pg) -> Mono.just(ResponseEntity.<Page<FileDetail>>ok(pg)))
 				.contextWrite(Context.of(LogUtil.METHOD_NAME, "AbstractResourceFileController.list"));
@@ -57,9 +59,10 @@ public abstract class AbstractResourceFileController<T extends AbstractFilesReso
 
 				SecurityContextUtil::getUsersContextAuthentication,
 
-				ca -> this.service.delete(CommonsUtil.nonNullValue(clientCode, ca.getClientCode(), ca.getLoggedInFromClientCode()),
-						request.getURI()
-								.toString()),
+		        ca -> this.service.delete(
+		                CommonsUtil.nonNullValue(clientCode, ca.getClientCode(), ca.getLoggedInFromClientCode()),
+		                request.getPath()
+		                        .toString()),
 
 				(ca, deleted) -> Mono.just(ResponseEntity.<Boolean>ok(deleted)))
 				.contextWrite(Context.of(LogUtil.METHOD_NAME, "AbstractResourceFileController.delete"));
@@ -113,7 +116,7 @@ public abstract class AbstractResourceFileController<T extends AbstractFilesReso
 			@RequestPart(name = "file", required = true) Mono<FilePart> filePart,
 			@RequestParam(required = false) String clientCode,
 			@RequestPart(required = false, name = "override") String override, ServerHttpRequest request) {
-
+		
 		return FlatMapUtil.flatMapMonoWithNull(
 
 				SecurityContextUtil::getUsersContextAuthentication,
@@ -121,10 +124,13 @@ public abstract class AbstractResourceFileController<T extends AbstractFilesReso
 				ca -> filePart,
 
 				(ca, fp) -> this.service
-						.createFromZipFile(CommonsUtil.nonNullValue(clientCode, ca.getClientCode(), ca.getLoggedInFromClientCode()),
-								request.getURI()
-										.toString(),
-								fp, override != null ? BooleanUtil.safeValueOf(override) : null))
+		                .createFromZipFile(
+		                        CommonsUtil.nonNullValue(clientCode, ca.getClientCode(),
+		                                ca.getLoggedInFromClientCode()),
+		                        request.getPath()
+		                                .toString(),
+		                        fp, override != null ? BooleanUtil.safeValueOf(override)
+		                                : null))
 				.map(ResponseEntity::ok)
 				.contextWrite(Context.of(LogUtil.METHOD_NAME, "AbstractResourceFileController.createWithZip"));
 	}

--- a/files/src/main/java/com/fincity/saas/files/controller/AbstractResourceFileController.java
+++ b/files/src/main/java/com/fincity/saas/files/controller/AbstractResourceFileController.java
@@ -78,10 +78,12 @@ public abstract class AbstractResourceFileController<T extends AbstractFilesReso
 
 				ca -> filePart,
 
-				(ca, fp) -> this.service.create(CommonsUtil.nonNullValue(clientCode, ca.getClientCode(), ca.getLoggedInFromClientCode()),
-						request.getURI()
-								.toString(),
-						fp, fileName, override != null ? BooleanUtil.safeValueOf(override) : null))
+		        (ca, fp) -> this.service.create(
+		                CommonsUtil.nonNullValue(clientCode, ca.getClientCode(), ca.getLoggedInFromClientCode()),
+		                request.getPath()
+		                        .toString(),
+		                fp, fileName, override != null ? BooleanUtil.safeValueOf(override)
+		                        : null))
 				.map(ResponseEntity::ok)
 				.contextWrite(Context.of(LogUtil.METHOD_NAME, "AbstractResourceFileController.create"));
 	}

--- a/files/src/main/java/com/fincity/saas/files/service/AbstractFilesResourceService.java
+++ b/files/src/main/java/com/fincity/saas/files/service/AbstractFilesResourceService.java
@@ -409,7 +409,7 @@ public abstract class AbstractFilesResourceService {
 	 * @return a Mono if the readAccess is granted by the requester
 	 */
 	protected Mono<Boolean> checkReadAccessWithClientCode(String resourcePath) {
-		return Mono.just(true); // should we make changes here
+		return Mono.just(true);
 	}
 
 	protected Mono<Void> makeMatchesStartDownload(DownloadOptions downloadOptions, ServerHttpRequest request,

--- a/files/src/main/java/com/fincity/saas/files/service/AbstractFilesResourceService.java
+++ b/files/src/main/java/com/fincity/saas/files/service/AbstractFilesResourceService.java
@@ -409,7 +409,7 @@ public abstract class AbstractFilesResourceService {
 	 * @return a Mono if the readAccess is granted by the requester
 	 */
 	protected Mono<Boolean> checkReadAccessWithClientCode(String resourcePath) {
-		return Mono.just(true);
+		return Mono.just(true); // should we make changes here
 	}
 
 	protected Mono<Void> makeMatchesStartDownload(DownloadOptions downloadOptions, ServerHttpRequest request,

--- a/security/src/main/java/com/fincity/security/controller/ClientController.java
+++ b/security/src/main/java/com/fincity/security/controller/ClientController.java
@@ -49,6 +49,14 @@ public class ClientController
 		return this.service.isUserBeingManaged(userId, clientCode)
 		        .map(ResponseEntity::ok);
 	}
+	
+	@GetMapping("/internal/validateClientCode")
+	public Mono<ResponseEntity<Boolean>> validateClientCode(@RequestParam String clientCode) {
+
+		return this.service.getClientBy(clientCode)
+		        .flatMap(e -> Mono.just(e != null))
+		        .map(ResponseEntity::ok);
+	}
 
 	@GetMapping("/internal/getClientNAppCode")
 	public Mono<ResponseEntity<Tuple2<String, String>>> getClientNAppCode(@RequestParam String scheme,


### PR DESCRIPTION
fixing when client code is passed as query param for creating an asset on files server and added additional check when system user is trying to create new path for non-exisiting client code.