### PR TITLE
Removed Header Caching for Secured files in AbstracFileResourceService

### DIFF
--- a/files/src/main/java/com/fincity/saas/files/service/AbstractFilesResourceService.java
+++ b/files/src/main/java/com/fincity/saas/files/service/AbstractFilesResourceService.java
@@ -477,8 +477,8 @@ public abstract class AbstractFilesResourceService {
 		respHeaders.set("x-cache", "MISS");
 		respHeaders.setLastModified(fileMillis);
 		respHeaders.setETag(eTag);
-		if (!downloadOptions.getNoCache()
-				.booleanValue())
+		if (!downloadOptions.getNoCache().booleanValue()
+				&& this.getResourceType().equals(FilesAccessPathResourceType.STATIC))
 			respHeaders.setCacheControl("public, max-age=3600");
 		respHeaders.setContentDisposition((downloadOptions.getDownload()
 				.booleanValue() ? ContentDisposition.attachment() : ContentDisposition.inline())


### PR DESCRIPTION
Added a ResourceType check for headers caching in sendfile method. Now only static files with false input of noCache option will be cached.