### PR TITLE
Added feature to copy authorities for user under same client

### DIFF
--- a/security/src/main/java/com/fincity/security/controller/UserController.java
+++ b/security/src/main/java/com/fincity/security/controller/UserController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import com.fincity.saas.commons.jooq.controller.AbstractJOOQUpdatableDataController;
@@ -117,5 +118,12 @@ public class UserController
 
 		return this.userService.resetPasswordRequest(authRequest, request)
 				.map(ResponseEntity::ok);
+	}
+
+	@PostMapping("/copy/authorities")
+	public Mono<ResponseEntity<Boolean>> copyUserAccess(@RequestParam ULong userId,
+			@RequestParam ULong referenceUserId) {
+
+		return this.userService.copyUserRolesNPermissions(userId, referenceUserId).map(ResponseEntity::ok);
 	}
 }

--- a/security/src/main/java/com/fincity/security/dao/UserDAO.java
+++ b/security/src/main/java/com/fincity/security/dao/UserDAO.java
@@ -675,17 +675,7 @@ public class UserDAO extends AbstractClientCheckDAO<SecurityUserRecord, ULong, U
 
 	public Mono<Boolean> copyRolesNPermissionsFromUser(ULong userId, ULong referenceUserId) {
 
-		var userAuth = this.dslContext
-				.select(SECURITY_USER_ROLE_PERMISSION.ROLE_ID, SECURITY_USER_ROLE_PERMISSION.PERMISSION_ID)
-				.from(SECURITY_USER_ROLE_PERMISSION)
-				.where(SECURITY_USER_ROLE_PERMISSION.USER_ID.eq(userId))
-				.asTable("existingAuthTable");
-
-		Field<ULong> userAuthRoleId = userAuth.field(SECURITY_USER_ROLE_PERMISSION.ROLE_ID);
-		Field<ULong> userAuthPermissionId = userAuth.field(SECURITY_USER_ROLE_PERMISSION.PERMISSION_ID);
-
 		return Mono.from(
-
 				this.dslContext
 						.insertInto(SECURITY_USER_ROLE_PERMISSION,
 								SECURITY_USER_ROLE_PERMISSION.USER_ID,
@@ -697,17 +687,9 @@ public class UserDAO extends AbstractClientCheckDAO<SecurityUserRecord, ULong, U
 										SECURITY_USER_ROLE_PERMISSION.ROLE_ID,
 										SECURITY_USER_ROLE_PERMISSION.PERMISSION_ID)
 										.from(SECURITY_USER_ROLE_PERMISSION)
-										.leftJoin(userAuth)
-										.on(SECURITY_USER_ROLE_PERMISSION.ROLE_ID.eq(userAuthRoleId)
-												.or(SECURITY_USER_ROLE_PERMISSION.ROLE_ID.isNull()
-														.and(userAuthRoleId.isNull())))
-										.and(SECURITY_USER_ROLE_PERMISSION.PERMISSION_ID.eq(userAuthPermissionId)
-												.or(SECURITY_USER_ROLE_PERMISSION.PERMISSION_ID.isNull()
-														.and(userAuthPermissionId.isNull())))
-										.where(SECURITY_USER_ROLE_PERMISSION.USER_ID.eq(referenceUserId)
-												.and(userAuthRoleId.isNull())
-												.and(userAuthPermissionId.isNull()))))
+										.where(SECURITY_USER_ROLE_PERMISSION.USER_ID.eq(referenceUserId)))
+						.onDuplicateKeyIgnore())
 				.map(rowsInserted -> rowsInserted > 0);
-	}
+	}	
 
 }

--- a/security/src/main/java/com/fincity/security/dao/UserDAO.java
+++ b/security/src/main/java/com/fincity/security/dao/UserDAO.java
@@ -673,4 +673,41 @@ public class UserDAO extends AbstractClientCheckDAO<SecurityUserRecord, ULong, U
 
 	}
 
+	public Mono<Boolean> copyRolesNPermissionsFromUser(ULong userId, ULong referenceUserId) {
+
+		var userAuth = this.dslContext
+				.select(SECURITY_USER_ROLE_PERMISSION.ROLE_ID, SECURITY_USER_ROLE_PERMISSION.PERMISSION_ID)
+				.from(SECURITY_USER_ROLE_PERMISSION)
+				.where(SECURITY_USER_ROLE_PERMISSION.USER_ID.eq(userId))
+				.asTable("existingAuthTable");
+
+		Field<ULong> userAuthRoleId = userAuth.field(SECURITY_USER_ROLE_PERMISSION.ROLE_ID);
+		Field<ULong> userAuthPermissionId = userAuth.field(SECURITY_USER_ROLE_PERMISSION.PERMISSION_ID);
+
+		return Mono.from(
+
+				this.dslContext
+						.insertInto(SECURITY_USER_ROLE_PERMISSION,
+								SECURITY_USER_ROLE_PERMISSION.USER_ID,
+								SECURITY_USER_ROLE_PERMISSION.ROLE_ID,
+								SECURITY_USER_ROLE_PERMISSION.PERMISSION_ID)
+						.select(
+								this.dslContext.select(
+										DSL.val(userId),
+										SECURITY_USER_ROLE_PERMISSION.ROLE_ID,
+										SECURITY_USER_ROLE_PERMISSION.PERMISSION_ID)
+										.from(SECURITY_USER_ROLE_PERMISSION)
+										.leftJoin(userAuth)
+										.on(SECURITY_USER_ROLE_PERMISSION.ROLE_ID.eq(userAuthRoleId)
+												.or(SECURITY_USER_ROLE_PERMISSION.ROLE_ID.isNull()
+														.and(userAuthRoleId.isNull())))
+										.and(SECURITY_USER_ROLE_PERMISSION.PERMISSION_ID.eq(userAuthPermissionId)
+												.or(SECURITY_USER_ROLE_PERMISSION.PERMISSION_ID.isNull()
+														.and(userAuthPermissionId.isNull())))
+										.where(SECURITY_USER_ROLE_PERMISSION.USER_ID.eq(referenceUserId)
+												.and(userAuthRoleId.isNull())
+												.and(userAuthPermissionId.isNull()))))
+				.map(rowsInserted -> rowsInserted > 0);
+	}
+
 }

--- a/security/src/main/java/com/fincity/security/service/SecurityMessageResourceService.java
+++ b/security/src/main/java/com/fincity/security/service/SecurityMessageResourceService.java
@@ -93,6 +93,7 @@ public class SecurityMessageResourceService extends AbstractMessageService {
 	public static final String FORBIDDEN_APP_REG_OBJECTS = "forbidden_app_reg_objects";
 	public static final String SUBDOMAIN_ALREADY_EXISTS = "subdomain_already_exists";
 	public static final String APP_DEPENDENCY_SAME_APP_CODE = "app_dependency_same_app_code";
+	public static final String FORBIDDEN_COPY_ROLE_PERMISSION = "forbidden_copying_role_permission";
 
 	public SecurityMessageResourceService() {
 

--- a/security/src/main/java/com/fincity/security/service/UserService.java
+++ b/security/src/main/java/com/fincity/security/service/UserService.java
@@ -955,4 +955,30 @@ public class UserService extends AbstractSecurityUpdatableDataService<SecurityUs
 				.setExpiresAt(token.getT2())
 				.setIpAddress(hostAddress));
 	}
+
+	@PreAuthorize("hasAuthority('Authorities.ASSIGN_Role_To_User') and hasAuthority('Authorities.ASSIGN_Permission_To_User')")
+	public Mono<Boolean> copyUserRolesNPermissions(ULong userId, ULong referenceUserId) {
+
+		return FlatMapUtil.flatMapMono(
+
+				SecurityContextUtil::getUsersContextAuthentication,
+
+				ca -> this.dao.readById(userId),
+
+				(ca, user) -> this.dao.readById(referenceUserId),
+
+				(ca, user, rUser) -> Mono.just(user.getClientId().equals(rUser.getClientId()))
+						.flatMap(BooleanUtil::safeValueOfWithEmpty),
+
+				(ca, user, rUser, isSameClient) -> ca.isSystemClient() ? Mono.just(true) :
+
+						clientService.isBeingManagedBy(ULongUtil.valueOf(ca.getUser().getClientId()), 
+
+						user.getClientId()).flatMap(BooleanUtil::safeValueOfWithEmpty),
+
+				(ca, user, rUser, isSameClient, sysOrManaged) -> this.dao.copyRolesNPermissionsFromUser(userId,
+						referenceUserId)
+
+		).contextWrite(Context.of(LogUtil.METHOD_NAME, "UserService.copyUserRolesNPermissions"));
+	}
 }


### PR DESCRIPTION
created a rest endpoint /api/security/users/copy/authorities which takes userId for target user and reference user. The api will add roles/permission for user from reference user's roles/permissions which aren't already added.