### PR TITLE
Fix bug in package and role creation

### DIFF
--- a/security/src/main/java/com/fincity/security/service/PackageService.java
+++ b/security/src/main/java/com/fincity/security/service/PackageService.java
@@ -91,6 +91,11 @@ public class PackageService extends
 						return super.create(entity);
 					}
 
+					if (entity.getAppId() == null)
+						return this.securityMessageResourceService.throwMessage(
+								msg -> new GenericException(HttpStatus.BAD_REQUEST, msg),
+								SecurityMessageResourceService.MANDATORY_APP_ID_CODE);
+										
 					entity.setBase(false);
 
 					ULong userClientId = ULongUtil.valueOf(ca.getUser()

--- a/security/src/main/java/com/fincity/security/service/RoleService.java
+++ b/security/src/main/java/com/fincity/security/service/RoleService.java
@@ -80,6 +80,11 @@ public class RoleService extends AbstractSecurityUpdatableDataService<SecurityRo
 					ULong userClientId = ULongUtil.valueOf(ca.getUser()
 							.getClientId());
 
+					if (entity.getAppId() == null)
+						return this.securityMessageResourceService.throwMessage(
+								msg -> new GenericException(HttpStatus.BAD_REQUEST, msg),
+								SecurityMessageResourceService.MANDATORY_APP_ID_CODE);
+
 					if (entity.getClientId() == null || userClientId.equals(entity.getClientId())) {
 						entity.setClientId(userClientId);
 						return super.create(entity);

--- a/security/src/main/resources/db/migration/V24__Update Packages and Roles Constraints.sql
+++ b/security/src/main/resources/db/migration/V24__Update Packages and Roles Constraints.sql
@@ -1,0 +1,9 @@
+use security;
+
+ALTER TABLE `security`.`security_package` DROP CONSTRAINT `UK2_PACKAGE_NAME`;
+
+ALTER TABLE `security`.`security_package` ADD CONSTRAINT `UK2_PACKAGE_NAME_APP_ID` UNIQUE (`NAME`, `APP_ID`);
+
+ALTER TABLE `security`.`security_role` DROP CONSTRAINT `UK1_ROLE_NAME`;
+
+ALTER TABLE `security`.`security_role` ADD CONSTRAINT  `UK1_ROLE_NAME_APP_ID` UNIQUE (`NAME`, `APP_ID`);

--- a/seed data/client_setup.sql
+++ b/seed data/client_setup.sql
@@ -1675,6 +1675,18 @@ use files;
 ALTER TABLE `files`.`files_access_path` 
 CHANGE COLUMN `PATH` `PATH` VARCHAR(1024) NOT NULL DEFAULT '' COMMENT 'Path to the resource' ;
 
+-- V24__Update Packages and Roles Constraints
+
+use security;
+
+ALTER TABLE `security`.`security_package` DROP CONSTRAINT `UK2_PACKAGE_NAME`;
+
+ALTER TABLE `security`.`security_package` ADD CONSTRAINT `UK2_PACKAGE_NAME_APP_ID` UNIQUE (`NAME`, `APP_ID`);
+
+ALTER TABLE `security`.`security_role` DROP CONSTRAINT `UK1_ROLE_NAME`;
+
+ALTER TABLE `security`.`security_role` ADD CONSTRAINT  `UK1_ROLE_NAME_APP_ID` UNIQUE (`NAME`, `APP_ID`);
+
 
 
 -- Add scripts from the project above this line and seed data below this line.


### PR DESCRIPTION
The bug caused not able to add same name packages/roles even when apps are different. In this fix we removed unique key constraint from name and added unique key constraint for combination of name and app_id. Also added mandatory check for existence of app_id if client_type is not system.